### PR TITLE
Add missing contact section translations

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -873,6 +873,13 @@
   "contact": {
     "title": "Contact Me",
     "description": "Welcome to discuss academic questions or collaboration opportunities with me",
+    "contactInfo": "Contact Information",
+    "email": "Email",
+    "phone": "Phone",
+    "address": "Office Address",
+    "academicSocial": "Academic & Social Profiles",
+    "sendMessage": "Send a Message",
+    "collaborationType": "Collaboration Type",
     "form": {
       "name": {
         "label": "Name",
@@ -955,9 +962,12 @@
       }
     },
     "info": {
-      "email": "Email",
-      "phone": "Phone",
-      "location": "Location",
+      "email": "zhaoyang.mou@example.com",
+      "phone": "+86 138-0000-0000",
+      "location": "Dalian, Liaoning, China",
+      "university": "Dalian Maritime University",
+      "department": "School of Artificial Intelligence",
+      "office": "Intelligent Robotics Laboratory, Room 305",
       "social": "Social Media"
     },
     "social": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -660,6 +660,13 @@
   "contact": {
     "title": "联系我",
     "description": "欢迎与我交流学术问题或合作机会",
+    "contactInfo": "联系信息",
+    "email": "电子邮箱",
+    "phone": "联系电话",
+    "address": "办公地址",
+    "academicSocial": "学术与社交平台",
+    "sendMessage": "发送消息",
+    "collaborationType": "合作类型",
     "form": {
       "name": {
         "label": "姓名",
@@ -742,9 +749,12 @@
       }
     },
     "info": {
-      "email": "邮箱",
-      "phone": "电话",
-      "location": "位置",
+      "email": "zhaoyang.mou@example.com",
+      "phone": "+86 138-0000-0000",
+      "location": "中国 辽宁 大连",
+      "university": "大连海事大学",
+      "department": "人工智能学院",
+      "office": "智能机器人实验室 305 室",
       "social": "社交媒体"
     },
     "social": {


### PR DESCRIPTION
## Summary
- add missing translations for contact page headings and labels in English and Chinese
- provide detailed contact information fields for both locales

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc2b692ca083278e8d9c9aadbe9843