### PR TITLE
Add missing search result localization strings

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -4,6 +4,14 @@
       "title": "Page Not Found",
       "description": "The page you are looking for does not exist or has been moved.",
       "backHome": "Back to Home"
+    },
+    "searchResults": {
+      "found": "Found",
+      "results": "results",
+      "containing": "containing",
+      "showing": "Showing",
+      "of": "of",
+      "items": "items"
     }
   },
   "navigation": {


### PR DESCRIPTION
## Summary
- add English translations for common search results labels including showing and of
- ensure search results UI renders localized copy instead of raw keys

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6940c37f0f1c83279ecfa408ea039ebb)